### PR TITLE
start port priority to webpack dev server port

### DIFF
--- a/subcommands/addCategories.js
+++ b/subcommands/addCategories.js
@@ -8,7 +8,7 @@ const { getCategories } = require('../utils/categoriesUtil')
 
 const addCategories = async (options) => {
   try {
-    appConfig.init()
+    await appConfig.init()
 
     const { all } = options
     const { dependencies } = appConfig.getAppConfig()

--- a/subcommands/addTags.js
+++ b/subcommands/addTags.js
@@ -6,7 +6,7 @@ const { spinnies } = require('../loader')
 const { appConfig } = require('../utils/appconfigStore')
 
 const addTags = async (options) => {
-  appConfig.init()
+  await appConfig.init()
 
   const { all } = options
   const { dependencies } = appConfig.getAppConfig()

--- a/subcommands/create.js
+++ b/subcommands/create.js
@@ -83,7 +83,7 @@ const create = async (userPassedName, options, _, returnBeforeCreatingTemplates,
     // logger.info(
     //   `${componentName} checked against registry and ${availableName} is finalized`
     // )
-    appConfig.init()
+    await appConfig.init()
     // const shortName = await getBloxShortName(availableName)
     const { bloxSource, cloneDirName, clonePath, bloxFinalName } = await createBlox(
       availableName,

--- a/subcommands/exec.js
+++ b/subcommands/exec.js
@@ -28,7 +28,7 @@ const appbloxexec = async (command, options) => {
   //   console.log('\n')
   //   process.exit(-1)
   // }
-  appConfig.init()
+  await appConfig.init()
   const bloxes = options.inside || []
   const missingBloxes = []
   const promiseArray = []

--- a/subcommands/log.js
+++ b/subcommands/log.js
@@ -3,7 +3,7 @@ const path = require('path')
 const { appConfig } = require('../utils/appconfigStore')
 
 const log = async (bloxname) => {
-  appConfig.init()
+  await appConfig.init()
   if (!appConfig.has(bloxname)) {
     console.log('Blox Doesnt exists')
     return

--- a/subcommands/ls.js
+++ b/subcommands/ls.js
@@ -3,7 +3,7 @@ const Table = require('cli-table')
 const { appConfig } = require('../utils/appconfigStore')
 
 const ls = async () => {
-  appConfig.init()
+  await appConfig.init()
   const table = new Table({
     head: ['Blox Name', 'Type', 'PID', 'Port', 'Log', 'Status'].map((v) => chalk.cyanBright(v)),
   })

--- a/subcommands/push.js
+++ b/subcommands/push.js
@@ -7,7 +7,7 @@ const push = async (bloxname, options) => {
   const { force } = options
   let { message } = options
 
-  appConfig.init()
+  await appConfig.init()
 
   if (!force && !bloxname) {
     console.log(chalk.red(`\nPlease provide a blox name or use -f to push all..`))

--- a/subcommands/push_config.js
+++ b/subcommands/push_config.js
@@ -7,7 +7,7 @@ const { getShieldHeader } = require('../utils/getHeaders')
 const { getBloxDetails } = require('../utils/registryUtils')
 
 const push_config = async () => {
-  appConfig.init()
+  await appConfig.init()
 
   const spinnies = new Spinnies()
 

--- a/subcommands/push_config.js
+++ b/subcommands/push_config.js
@@ -1,5 +1,6 @@
 const { default: axios } = require('axios')
 const chalk = require('chalk')
+const Spinnies = require('spinnies')
 const { appBloxUpdateAppConfig } = require('../utils/api')
 const { appConfig } = require('../utils/appconfigStore')
 const { getShieldHeader } = require('../utils/getHeaders')
@@ -7,44 +8,54 @@ const { getBloxDetails } = require('../utils/registryUtils')
 
 const push_config = async () => {
   appConfig.init()
+
+  const spinnies = new Spinnies()
+
   const name = appConfig.getName()
+
+  spinnies.add('pushConfig', { text: `Getting details of ${name}` })
+
   // TODO - write a utility function wrapping getBloxDetails, should be able to call getBloxID
   const ID = await getBloxDetails(name)
     .then((res) => {
       if (res.status === 204) {
-        console.log(`${name} not found in registry.`)
+        spinnies.fail('pushConfig', { text: `${name} not found in registry.` })
         process.exit(1)
       }
       if (res.data.err) {
-        console.log(`Error getting details..`)
+        spinnies.fail('pushConfig', { text: `Error getting details from registry.` })
         process.exit(1)
       }
       // Make sure it is registered as appBlox, else unregistered
       if (res.data.data.BloxType !== 1) {
-        console.log(`${name} is not registered as appblox`)
+        spinnies.fail('pushConfig', { text: `${name} is not registered as appblox` })
         process.exit(1)
       }
       // eslint-disable-next-line no-param-reassign
       return res.data.data.ID
     })
-    .catch(() => {
-      console.log('Something went terribly wrong...')
+    .catch((err) => {
+      spinnies.fail('pushConfig', { text: `Something went terribly wrong...` })
+      console.log(err)
       process.exit(1)
     })
 
+  spinnies.update('pushConfig', { text: 'Preparing config to upload' })
   const data = {
     blox_id: ID,
     app_config: appConfig.getAppConfig(),
   }
   const headers = getShieldHeader()
+  spinnies.update('pushConfig', { text: 'Pushing..' })
   try {
-    const appconfig = await axios.post(appBloxUpdateAppConfig, { ...data }, { headers })
-    console.log(appconfig)
-    console.log('DONE')
+    await axios.post(appBloxUpdateAppConfig, { ...data }, { headers })
+    spinnies.succeed('pushConfig', { text: 'Appconfig pushed!' })
   } catch (err) {
+    spinnies.fail('pushConfig', { text: 'Failed!' })
     console.log(chalk.dim(err.message))
     console.log(chalk.red(`Couldn't upload ..try again later`))
   }
+  spinnies.remove('pushConfig')
 }
 
 module.exports = push_config

--- a/subcommands/start.js
+++ b/subcommands/start.js
@@ -49,7 +49,7 @@ const watchCompilation = (fileName) =>
   })
 const spinnies = new Spinnies()
 const start = async (bloxname) => {
-  appConfig.init()
+  await appConfig.init()
   // Setup env from appblox.config.json data
   const configData = appConfig.appConfig
   await setupEnv(configData)

--- a/subcommands/stop.js
+++ b/subcommands/stop.js
@@ -6,7 +6,7 @@ const { appConfig } = require('../utils/appconfigStore')
 global.rootDir = process.cwd()
 
 const stop = async (name) => {
-  appConfig.init()
+  await appConfig.init()
   if (!name) {
     stopAllBlox()
   } else if (appConfig.has(name)) {

--- a/utils/bloxValidationRunner.js
+++ b/utils/bloxValidationRunner.js
@@ -9,7 +9,7 @@ async function BloxValidationRunner(bloxPath, taskArray) {
     if (typeof fn !== 'function') throw new Error('Expexted task to be a function')
     await fn.apply(null, [appConfig, bloxConfig, cwd])
   }
-  appConfig.init()
+  await appConfig.init()
   const testDIrectory = appConfig.getBlox(appConfig.allBloxNames.next().value).directory
   console.log(testDIrectory)
   // const file = await readFile(`${testDIrectory}/src/todoInput.js`, { encoding: 'utf8' })


### PR DESCRIPTION
# Pull Request Template

## Description

Start command till now, assigned random ports to UI-Bloxes, this was causing issue with shield SDKwhich expected container bloxes to start at specific ports for the redirection to work as expected. 
This PR fixes the issue by reading the port from webpack config and assigning it if available or else the adjacent free port.

Fixes # (issue)
No longer assigning random ports to ui bloxes on start

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Manually

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
